### PR TITLE
Inclusion of the parameter digits in spa_creator

### DIFF
--- a/R/builder_functions.R
+++ b/R/builder_functions.R
@@ -371,6 +371,14 @@ spa_creator <- function(tbl, fuzz_policy = "fsp", const_policy = "voronoi", ...)
                                    The values are 'fsp' and 'fsc'."), call. = FALSE)
                        )
 
+  if("digits" %in% names(params)) {
+    if(is_integer(params$digits)){
+      fuzz_stage[ , 4:ncol(fuzz_stage)] <- round(fuzz_stage[ , 4:ncol(fuzz_stage)], params$digits)
+    } else {
+      stop("The digits argument have to be a integer.", call. = FALSE)
+    }
+  }
+  
   # second step is to apply the construction step
   result <- switch (const_policy,
     voronoi = do.call(voronoi_diagram_policy, c(list(lp = fuzz_stage), params)),


### PR DESCRIPTION
In this pull request, I propose the inclusion of the parameter digits in spa_creator to round the membership degrees of the fuzzification stage. The documentation of this parameter needs to be produced.