### PR TITLE
Updates to handle pcomposition and pcollection objects

### DIFF
--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -682,7 +682,7 @@ tibble::as_tibble
 #' @return
 #' 
 #' A tibble object of size `n x 2` where `n` is the number of components of 
-#' the `pgeometry` object and two columns in the format `(md, geometry)`.
+#' the `pgeometry` object and two columns in the format `(geometry, md)`.
 #' 
 #' @examples
 #' 

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -602,14 +602,6 @@ create_pgeometry <- function(x, type, is_valid = FALSE){
                   }
                 }
                 
-                # # Calculate support and order components according to the membership degree
-                # if(!length(unlist(components))){
-                #   supp <- st_geometrycollection()
-                # }else{
-                #   pgo <- compute_support(unlist(components), type)
-                #   supp <- pgo[[2]]
-                # }
-                
               }
             } else if (type == "PLATEAUCOLLECTION"){
               
@@ -1046,22 +1038,8 @@ get_counter_ctype <- function(pgo){
   type <- switch(ptype,
                  PLATEAUPOINT = "POINT",
                  PLATEAULINE = "LINESTRING",
-                 PLATEAUREGION = "POLYGON")
+                 PLATEAUREGION = "POLYGON",
+                 PLATEAUCOMPOSITION = "GEOMETRYCOLLECTION",
+                 PLATEAUCOLLECTION = "GEOMETRYCOLLECTION")
   type
-}
-
-#' @import sf methods
-#' @noRd
-append_valid_comps <- function(sfg, pgo, md, lcomps){
-  ptype = spa_get_type(pgo)
-  if(!st_is_empty(sfg) && is_compatible(sfg, ptype) && md > 0 && md <= 1){
-    result_comp <- new("component", obj = sfg, md = md)
-    lcomps <- append(lcomps, result_comp)
-  } else if(!st_is_empty(sfg) && st_geometry_type(sfg) == "GEOMETRYCOLLECTION") {
-    type_geom <- get_counter_ctype(pgo)
-    obj <- obj_union(sfg, type_geom)
-    result_comp <- new("component", obj = obj, md = md)
-    lcomps <- append(lcomps, result_comp)
-  }
-  lcomps
 }

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -922,9 +922,11 @@ fsr_plot <- function(pgo, base_poly = NULL, add_base_poly = TRUE, low = "white",
   
   if(nrow(points) != 0){
     if(!is.null(plot)){
-      plot <- plot + geom_sf(data = points, aes(color = .data$md, geometry = .data$geometry), ...) +
-        scale_colour_gradient(name = "", limits = c(0, 1), low = low, high = high) +
+      plot <- plot + geom_sf(data = points, aes(color = .data$md, geometry = .data$geometry), ...)
+      if(nrow(lines) == 0){
+        plot <- plot + scale_colour_gradient(name = "", limits = c(0, 1), low = low, high = high) +
         theme_classic()
+      }
     } else{
       plot <- ggplot() + geom_sf(data = points, aes(color = .data$md, geometry = .data$geometry), ...) +
         scale_colour_gradient(name = "", limits = c(0, 1), low = low, high = high) +


### PR DESCRIPTION
Changes in a set of functions to deal with `pcomposition` and `pcollection` objects. This set of functions include fuzzy numerical operations, fuzzy geometric set operations, and related functions (i.e., `spa_add_component`, `spa_eval`, `spa_core`, `spa_exact_equal`, `spa_exact_inside`, `spa_boundary`, and `check_spa_topological_condition`). Further, some functions are now deprecated (`spa_common_points` and `spa_boundary_pregion`). The fuzzy topological relationships still work only for `pregion` objects (but some minor modifications were needed because of the updates on classes and internal functions).


Inclusion of a set of internal functions to manipulate `pcomposition` and `pcollection` objects in the previous operations. Further, some external functions are now available: `pcollection_to_pcomposition` and `spa_flatten`.

According to the following papers:

- [Carniel, A. C.; Schneider, M. Spatial Plateau Algebra: An Executable Type System for Fuzzy Spatial Data Types. In Proceedings of the 2018 IEEE International Conference on Fuzzy Systems (FUZZ-IEEE 2018), pp. 1-8, 2018.](https://ieeexplore.ieee.org/document/8491565)
- [Carniel, A. C.; Schneider, M. Spatial Data Types for Heterogeneously Structured Fuzzy Spatial Collections and Compositions. In Proceedings of the 2020 IEEE International Conference on Fuzzy Systems (FUZZ-IEEE 2020), pp. 1-8, 2020.](https://ieeexplore.ieee.org/document/9177620)

